### PR TITLE
Added drs elements/attributes to simulation config (closes #17)

### DIFF
--- a/config/control_cmor_template.ini
+++ b/config/control_cmor_template.ini
@@ -60,7 +60,7 @@ DirDerotated=work/output_derotated
 #
 # The 25 mandatory attributes are:
 # project_id,product,mip_era,activity_id,domain_id,institution_id,driving_source_id,driving_experiment_id,driving_variant_label,source_id,version_realisation,frequency,driving_institution_id,
-# contact,creation_date,driving_experiment,Conventions,institution,tracking_id,source,source_type,variable_id,domain,native_resolution,license
+# contact,creation_date,driving_experiment,Conventions,institution,tracking_id,source,source_type,variable_id,domain,grid,license
 #
 # All other attributes are optional.
 # Entries for listed attributes are defined in section 'settings' below; each attribute set in "global_attr_list" needs an entry/"value", otherwise the tool will stop.
@@ -77,7 +77,7 @@ DirDerotated=work/output_derotated
 # Optional arguments not included:
 # comment,history,references
 
-global_attr_list=Conventions,project_id,mip_era,activity_id,domain_id,institution_id,driving_source_id,driving_experiment_id,driving_variant_label,source_id,version_realisation,driving_institution_id,contact,driving_experiment,institution,source,source_type,domain,native_resolution,license
+global_attr_list=Conventions,project_id,mip_era,activity_id,domain_id,institution_id,driving_source_id,driving_experiment_id,driving_variant_label,source_id,version_realisation,driving_institution_id,contact,driving_experiment,institution,source,source_type,domain,grid,license
 #
 
 #global attributes that should be taken from .nc files if present; will overwrite settings from global_attr_list!
@@ -251,35 +251,34 @@ driving_variant_label={driving_variant_label}
 driving_institution_id={driving_institution_id}
 
 #domian_id: an identifier assigned to each CORDEX region including a flag for resolution https://github.com/WCRP-CORDEX/cordex-cmip6-cv/blob/main/CORDEX-CMIP6_domain_id.json
-domain_id=EUR-12
+domain_id={domain_id}
 
 #domain: name of the CORDEX region https://github.com/WCRP-CORDEX/cordex-cmip6-cv/blob/main/CORDEX-CMIP6_domain_id.json
-domain=Europe
+domain={domain}
 
-#native_resolution: provides information about resolution of native model grids in km or deg or more detailed description of unstructured grids
-# e.g. 25km, 12.5km, 0.22deg, 0.11deg
-native_resolution=12.5km
+#grid: The grid global attribute can be used to describe the horizontal grid and regridding procedure
+grid={grid}
 
 #institution_id: usually from this list
-institution_id=HCLIMcom-SMHI
+institution_id={institution_id}
 
 #institution: full name of the institution that is responsible for the CORDEX simulations
-institution=The HARMONIE Climate Modelling Community (HCLIMcom)
+institution={institution}
 
 #source_id: an identifier (acronym) of the CORDEX RCM
-source_id=HCLIM43-ALADIN
+source_id={source_id}
 
 #source: full model name/version and components (aerosol, atmos, land etc.)
-source=HARMONIE Climate Modelling Community (HCLIM-Com)
+source={source}
 
 #source_type: model configuration (e.g. ARCM, AORCM, AGCM)
-source_type=ARCM
+source_type={source_type}
 
 #contact: email address
-contact=rossby@smhi.se
+contact={contact}
 
 #version_realisation: identifies version of CORDEX datasets and RCM realisations
-version_realisation=v1-r1
+version_realisation={version_realisation}
 
 #license: provides information about the license (link to table with information about the license for all CORDEX-CMIP6 RCMs.)
 license=https://cordex.org/data-access/cordex-cmip6-data/cordex-cmip6-terms-of-use

--- a/config/simulation_config.yml
+++ b/config/simulation_config.yml
@@ -30,13 +30,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 1980
     end_year: 2021
 
@@ -50,13 +50,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -70,13 +70,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -90,13 +90,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -110,13 +110,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -130,13 +130,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -150,13 +150,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -170,13 +170,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
-    institution_id: "HCLIMcom-SMHI"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Norwegian Meteorological Institute (METNo), Oslo, Norway"
+    institution_id: "HCLIMcom-METNo"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "cordex@met.no"
     start_year: 1951
     end_year: 2014
 
@@ -190,13 +190,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
-    institution_id: "HCLIMcom-SMHI"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Norwegian Meteorological Institute (METNo), Oslo, Norway"
+    institution_id: "HCLIMcom-METNo"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "cordex@met.no"
     start_year: 2015
     end_year: 2100
 
@@ -210,13 +210,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -230,13 +230,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -250,13 +250,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -270,13 +270,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -290,13 +290,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -310,13 +310,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -330,13 +330,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -350,13 +350,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -370,13 +370,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -390,13 +390,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -410,13 +410,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -430,13 +430,13 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Swedish Meteorological and Hydrological Institute (SMHI), Norrkoping, Sweden"
     institution_id: "HCLIMcom-SMHI"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "rossby.cordex@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -450,12 +450,12 @@ simulations:
     domain: "Europe"
     domain_id: "EUR-12"
     grid: "Lambert conic conformal with 12.5 km grid spacing"
-    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
-    institution_id: "HCLIMcom-SMHI"
+    institution: "HARMONIE Climate Modelling Community (HCLIMcom) partner: Norwegian Meteorological Institute (METNo), Oslo, Norway"
+    institution_id: "HCLIMcom-METNo"
     version_realisation: "v1-r1"
-    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source: "HARMONIE Climate model cycle 43 with ALADIN physics"
     source_type: "ARCM"
     source_id: "HCLIM43-ALADIN"
-    contact: "rossby@smhi.se"
+    contact: "cordex@met.no"
     start_year: 2015
     end_year: 2100

--- a/config/simulation_config.yml
+++ b/config/simulation_config.yml
@@ -27,6 +27,16 @@ simulations:
     driving_experiment: "reanalysis"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "ECMWF"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 1980
     end_year: 2021
 
@@ -37,6 +47,16 @@ simulations:
     driving_experiment: "all-forcing simulation of the recent past"
     driving_variant_label: "r1i1p1f2"
     driving_institution_id: "CNRM-CERFACS"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -47,6 +67,16 @@ simulations:
     driving_experiment: "gap-filling scenario reaching 7.0 based on SSP3"
     driving_variant_label: "r1i1p1f2"
     driving_institution_id: "CNRM-CERFACS"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -57,6 +87,16 @@ simulations:
     driving_experiment: "update of RCP2.6 based on SSP1"
     driving_variant_label: "r1i1p1f2"
     driving_institution_id: "CNRM-CERFACS"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -67,6 +107,16 @@ simulations:
     driving_experiment: "all-forcing simulation of the recent past"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "MIROC"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -77,6 +127,16 @@ simulations:
     driving_experiment: "gap-filling scenario reaching 7.0 based on SSP3"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "MIROC"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -87,6 +147,16 @@ simulations:
     driving_experiment: "update of RCP2.6 based on SSP1"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "MIROC"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -97,6 +167,16 @@ simulations:
     driving_experiment: "all-forcing simulation of the recent past"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "NCC"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -107,6 +187,16 @@ simulations:
     driving_experiment: "gap-filling scenario reaching 7.0 based on SSP3"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "NCC"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -117,6 +207,16 @@ simulations:
     driving_experiment: "all-forcing simulation of the recent past"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -127,6 +227,16 @@ simulations:
     driving_experiment: "all-forcing simulation of the recent past"
     driving_variant_label: "r2i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -137,6 +247,16 @@ simulations:
     driving_experiment: "update of RCP2.6 based on SSP1"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -147,6 +267,16 @@ simulations:
     driving_experiment: "gap-filling scenario reaching 7.0 based on SSP3"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -157,6 +287,16 @@ simulations:
     driving_experiment: "update of RCP2.6 based on SSP1"
     driving_variant_label: "r2i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -167,6 +307,16 @@ simulations:
     driving_experiment: "gap-filling scenario reaching 7.0 based on SSP3"
     driving_variant_label: "r2i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -177,6 +327,16 @@ simulations:
     driving_experiment: "all-forcing simulation of the recent past"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "MPI-M"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -187,6 +347,16 @@ simulations:
     driving_experiment: "update of RCP2.6 based on SSP1"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "MPI-M"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -197,6 +367,16 @@ simulations:
     driving_experiment: "gap-filling scenario reaching 7.0 based on SSP3"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "MPI-M"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -207,6 +387,16 @@ simulations:
     driving_experiment: "all-forcing simulation of the recent past"
     driving_variant_label: "r3i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 1951
     end_year: 2014
 
@@ -217,6 +407,16 @@ simulations:
     driving_experiment: "update of RCP2.6 based on SSP1"
     driving_variant_label: "r3i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -227,6 +427,16 @@ simulations:
     driving_experiment: "gap-filling scenario reaching 7.0 based on SSP3"
     driving_variant_label: "r3i1p1f1"
     driving_institution_id: "EC-Earth-Consortium"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100
 
@@ -237,5 +447,15 @@ simulations:
     driving_experiment: "update of RCP2.6 based on SSP1"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "NCC"
+    domain: "Europe"
+    domain_id: "EUR-12"
+    grid: "Lambert conic conformal with 12.5 km grid spacing"
+    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
+    institution_id: "HCLIMcom-SMHI"
+    version_realisation: "v1-r1"
+    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
+    source_type: "ARCM"
+    source_id: "HCLIM43-ALADIN"
+    contact: "rossby@smhi.se"
     start_year: 2015
     end_year: 2100


### PR DESCRIPTION
I've added the following drs elements / global attributes to the simulation config:
```
    domain: "Europe"
    domain_id: "EUR-12"
    grid: "Lambert conic conformal with 12.5 km grid spacing"
    institution: "The HARMONIE Climate Modelling Community (HCLIMcom)"
    institution_id: "HCLIMcom-SMHI"
    version_realisation: "v1-r1"
    source: "HARMONIE Climate Modelling Community (HCLIM-Com)"
    source_type: "ARCM"
    source_id: "HCLIM43-ALADIN"
    contact: "rossby@smhi.se"
```

- I've added what was mentioned in the issue (#17), plus `source` and `source_type`. The `grid` attribute replaces `native_resolution`, which I've removed.
- I have _not_ inspected the list of global attributes in `control_cmor_template.ini` to make sure it still matches the spec.

The PR is created as draft, to make sure all things are correct before merging.
- I know there are some values that should be changed, let me know which ones you want changed.
- I've added the same values to all simulations, is that correct?