### PR TITLE
Added product to control_cmor_template.ini

### DIFF
--- a/config/control_cmor_template.ini
+++ b/config/control_cmor_template.ini
@@ -225,6 +225,9 @@ var_list_fixed=orog,sftlf
 #Conventions: used version of CF conventions
 Conventions=CF-1.11
 
+#product: product type (model-output is the only option)
+product=model-output
+
 #project_id: project identifier (CORDEX is the only option)
 project_id=CORDEX
 

--- a/src/CMORlight/tools.py
+++ b/src/CMORlight/tools.py
@@ -83,10 +83,6 @@ def set_attributes(params):
         except:
             raise Exception("Global attribute %s is in global_attr_list but is not defined in the configuration file!" % name.strip())
 
-    #Invariant attributes
-    #settings.Global_attributes['project_id']="CORDEX" #global attribute "project_id" should be variable, thus defined in the ini-file
-    settings.Global_attributes['product']="output"
-
     # set addtitional netcdf attributes
     settings.netCDF_attributes['RCM_NAME'] = params[config.get_config_value('index','INDEX_VAR')]
     settings.netCDF_attributes['RCM_NAME_ORG'] = params[config.get_config_value('index','INDEX_RCM_NAME_ORG')]


### PR DESCRIPTION
`product` was added to `global_attr_list` in a previous commit, which causes an exception since it is not set in `control_cmor_template.ini`. I've added the setting to `control_cmor_template.ini`, with a clear comment that there is only one acceptable value, and removed the code where it is explicitly set in `tools.py`.