### PR TITLE
Don't set coordinates if coordinates file not specified (fixes #25)

### DIFF
--- a/config/control_cmor_template.ini
+++ b/config/control_cmor_template.ini
@@ -201,7 +201,7 @@ AGG_SEM = 10
 [settings_{simulation}]
 
 # file with lon/lat [and perhaps vertices]
-coordinates_file=coordinates_HCLIM_EUR11.nc
+coordinates_file=
 
 # file with vertices [and perhaps lon/lat]
 vertices_file=

--- a/src/CMORlight/settings.py
+++ b/src/CMORlight/settings.py
@@ -65,10 +65,10 @@ def init(vartable):
     FMT = '%Y-%m-%d %H:%M:%S'
 
     global vertices_file
-    vertices_file = ("%s/%s" % (DirConfig,config.get_sim_value('vertices_file', exitprog = False)))
+    vertices_file = ("%s/%s" % (DirConfig,config.get_sim_value('vertices_file', exitprog=False)))
 
     global coordinates_file
-    coordinates_file = ("%s/%s" % (DirConfig,config.get_sim_value('coordinates_file')))
+    coordinates_file = ("%s/%s" % (DirConfig,config.get_sim_value('coordinates_file', exitprog=False)))
 
     # dictionary for global attributes
     global Global_attributes

--- a/src/CMORlight/tools.py
+++ b/src/CMORlight/tools.py
@@ -625,7 +625,12 @@ def add_coordinates(f_out,logger=log):
     Add lat,lon and Lambert_Conformal to output file from coordinates file if present there
     '''
     if os.path.isfile(settings.coordinates_file):
-        f_coor = Dataset(settings.coordinates_file,'r')
+        try:
+            f_coor = Dataset(settings.coordinates_file,'r')
+        except FileNotFoundError:
+            # Coordinates file was specified but not found
+            raise Exception("Coordinates file %s does not exist!" % settings.coordinates_file)
+
         try:
             # copy lon
             copy_var(f_coor,f_out,'lon',logger=logger)
@@ -643,9 +648,6 @@ def add_coordinates(f_out,logger=log):
             f_coor.close()
         except IndexError:
             raise IndexError("\n Coordinates file does not have the same resolution as the input data! Change it!")
-    elif settings.coordinates_file != "":
-        # Coordinates file was specified but not found
-        raise Exception("Coordinates file %s does not exist!" % settings.coordinates_file)
     else:
         log.info(
             "Coordinates file not specified, leaving coordinate data as is"

--- a/src/CMORlight/tools.py
+++ b/src/CMORlight/tools.py
@@ -643,8 +643,13 @@ def add_coordinates(f_out,logger=log):
             f_coor.close()
         except IndexError:
             raise IndexError("\n Coordinates file does not have the same resolution as the input data! Change it!")
-    else:
+    elif settings.coordinates_file != "":
+        # Coordinates file was specified but not found
         raise Exception("Coordinates file %s does not exist!" % settings.coordinates_file)
+    else:
+        log.info(
+            "Coordinates file not specified, leaving coordinate data as is"
+        )
 
 # -----------------------------------------------------------------------------
 def get_derotate_vars():


### PR DESCRIPTION
Closes #25 

`coordinates_file` in `control_cmor_template.ini` can now be left empty, to preserve coordinate data from source file.

Leaving the value default empty.