### PR TITLE
Variables table updating

### DIFF
--- a/src/CMORlight/Config/CORDEX6_CMOR_HCLIM_variables_table.csv
+++ b/src/CMORlight/Config/CORDEX6_CMOR_HCLIM_variables_table.csv
@@ -117,7 +117,7 @@ va50m;va50m;va50m;;;ModelLevel;1;;point;mean;mean;;50;m s-1;;24;i;1;;1;;;;;North
 ta50m;ta50m;ta50m;;;ModelLevel;1;;point;mean;mean;;50;K;;24;i;1;;1;;;;;Air Temperature at 50m;;air_temperature;;atmos;
 hus50m;hus50m;hus50m;;;ModelLevel;1;;point;mean;mean;;50;1;;24;i;1;;1;;;;;Specific Humidity at 50m;;specific_humidity;;atmos;
 z0;z0;z0;;;ModelLevel;1;; ;maximum;maximum within days time: mean over days;;0;m;;;i;1;;1;;;;;Surface Roughness Length;;surface_roughness_length;;;
-cape;cape;CAPE;;;ModelLevel;1;;;maximum;;;0;J kg-1;;;a;1;;;;;;;2-D Convective Available Potential Energy;;atmosphere_convective_available_potential_energy_wrt_surface;;atmos;
+cape;cape;cape;;;ModelLevel;1;;;maximum;;;0;J kg-1;;;a;1;;;;;;;2-D Convective Available Potential Energy;;atmosphere_convective_available_potential_energy_wrt_surface;;atmos;
 ua300m;ua300m;ua300m;;;ModelLevel;1;;point;mean;mean;;300;m s-1;;24;i;1;;1;;;;;Eastward wind at 300 m;;eastward_wind;;atmos;
 va300m;va300m;va300m;;;ModelLevel;1;;point;mean;mean;;300;m s-1;;24;i;1;;1;;;;;Northward wind at 300 m;;northward_wind;;atmos;
 sftgif;sftgif;sftgif;;;;1;;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Covered by Glacier;;land_ice_area_fraction;;;

--- a/src/CMORlight/Config/CORDEX6_CMOR_HCLIM_variables_table.csv
+++ b/src/CMORlight/Config/CORDEX6_CMOR_HCLIM_variables_table.csv
@@ -6,121 +6,121 @@ HCLIM variable name;HCLIM variable name (in model output file);output variable n
 [1/sem]";ag;fx;long_name;comment;standard_name;direction of positive fluxes;"realm
 (not required, however, if included should have the value as in CMIP5)";"cell-method: area
 (optional)"
-tas;tas;tas;;;ModelLevel;1;;point;mean;mean;;2;K;;24;i;1;;1;;;;;Near-Surface Air Temperature;;air_temperature;;atmos;
-tasmax;tasmax;tasmax;;;ModelLevel;1;;;maximum;maximum within days time: mean over days;;2;K;;;a;1;;1;;;;;Daily Maximum Near-Surface Air Temperature;;air_temperature;;atmos;
-tasmin;tasmin;tasmin;;;ModelLevel;1;;;minimum;minimum within days time: mean over days;;2;K;;;a;1;;1;;;;;Daily Minimum Near-Surface Air Temperature;;air_temperature;;atmos;
-pr;pr;pr;;;ModelLevel;1;;mean;mean;mean;;0;kg m-2 s-1;;24;a;1;;1;;;;;Precipitation;;precipitation_flux;;atmos;
-ps;ps;ps;;;ModelLevel;1;;point;mean;mean;;0;Pa;;24;i;1;;1;;;;;Surface Air Pressure;;surface_air_pressure;;atmos;
-evspsbl;evspsbl;evspsbl;;;ModelLevel;1;;mean;mean;mean;;0;kg m-2 s-1;;24;a;1;;1;;;;;Evaporation including Sublimation and Transpiration;;water_evaporation_flux;;atmos;
-huss;huss;huss;;;ModelLevel;1;;point;mean;mean;;2;1;;24;i;1;;1;;;;;Near-Surface Specific Humidity;;specific_humidity;;atmos;
-hurs;hurs;hurs;;;ModelLevel;1;;point;mean;mean;;2;%;;24;i;1;;1;;;;;Near-Surface Relative Humidity;;relative_humidity;;atmos;
-psl;psl;psl;;;ModelLevel;1;;point;mean;mean;;0;Pa;;24;i;1;;1;;;;;Sea Level Pressure;;air_pressure_at_mean_sea_level;;atmos;
-sfcWind;sfcWind;sfcWind;;;ModelLevel;1;;point;mean;mean;;10;m s-1;;24;i;1;;1;;;;;Near-Surface Wind Speed;;wind_speed;;atmos;
-uas;uas;uas;;;ModelLevel;1;;point;mean;mean;;10;m s-1;;24;i;1;;1;;;;;Eastward Near-Surface Wind;;eastward_wind;;atmos;
-vas;vas;vas;;;ModelLevel;1;;point;mean;mean;;10;m s-1;;24;i;1;;1;;;;;Northward Near-Surface Wind;;northward_wind;;atmos;
-clt;clt;clt;;;ModelLevel;1;;mean;mean;mean;;0;%;;24;a;1;;1;;;;;Total Cloud Cover Percentage;;cloud_area_fraction;;atmos;
-rsds;rsds;rsds;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;Surface Downwelling Shortwave Radiation;;surface_downwelling_shortwave_flux_in_air;down;atmos;
-rlds;rlds;rlds;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;Surface Downwelling Longwave Radiation;;surface_downwelling_longwave_flux_in_air;down;atmos;
-orog;orog;orog;;;;1;;;;;;;m;;;;;;;;;;0;Surface Altitude;;surface_altitude;;atmos;
-sftlf;sftlf;sftlf;sftnf + sfturf;;;1;;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Occupied by Land;;land_area_fraction;;atmos;
-ts;ts;ts;;;ModelLevel;1;;point;mean;mean;;0;K;;24;i;1;;1;;;;;Surface Temperature;;surface_temperature;;atmos;
-tsl;tsl;tsl;tsl_L01:L14;;ModelLevel;1;;point;mean;mean;;0;K;;4;i;1;;1;;;;;Temperature of Soil;Temperature of each soil layer. Reported as missing for grid cells with no land.;soil_temperature;;land;mean where land
-prc;prc;prc;;;ModelLevel;1;;mean;mean;mean;;0;kg m-2 s-1;;24;a;1;;1;;;;;Convective Precipitation;;convective_precipitation_flux;;atmos;
-prhmax;prhmax;prhmax;daymax(pr);;ModelLevel;1;;;maximum;maximum within days time: mean over days;;0;kg m-2 s-1;;;a;1;;1;;;;;Daily Maximum Hourly Precipitation Rate;;precipitation_flux;;atmos;
-prsn;prsn;prsn;;;ModelLevel;1;;mean;mean;mean;;0;kg m-2 s-1;;24;a;1;;1;;;;;Snowfall Flux;;snowfall_flux;;atmos;
-mrros;mrros;mrros;;;ModelLevel;;;mean;mean;mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Surface Runoff;;surface_runoff_flux;;land;mean where land
-mrro;mrro;mrro;mrrod + mrros;;ModelLevel;;;mean;mean;mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Total Runoff;;runoff_flux;;land;mean where land
-snm;snm;snm;;;ModelLevel;;;mean;mean;mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Surface Snow Melt;;surface_snow_melt_flux;;landIce land;mean where land
-tauu;tauu;tauu;;;ModelLevel;1;;mean;mean;mean;;0;Pa;;4;a;1;;1;;;;;Surface Downward Eastward Wind Stress;;surface_downward_eastward_stress;down;atmos;
-tauv;tauv;tauv;;;ModelLevel;1;;mean;mean;mean;;0;Pa;;4;a;1;;1;;;;;Surface Downward Northward Wind Stress;;surface_downward_northward_stress;down;atmos;
-sfcWindmax;sfcWindmax;sfcWindmax;;;ModelLevel;1;;;maximum;maximum within days time: mean over days;;10;m s-1;;;a;1;;1;;;;;Daily Maximum Near-Surface Wind Speed;;wind_speed;;atmos;
-wsgsmax;wsgsmax;wsgsmax;;;ModelLevel;1;;maximum;maximum;maximum within days time: mean over days;;10;m s-1;;8;a;1;;1;;;;;Daily Maximum Near-Surface Wind Speed of Gust;;wind_speed_of_gust;;atmos;
-sund;sund;sund;;;ModelLevel;1;;;sum;sum within days time: mean over days;;0;s;;;a;1;;1;;;;;Daily Duration of Sunshine;;duration_of_sunshine;;atmos;
-rsdsdir;rsdsdir;rsdsdir;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;Surface Direct Downwelling Shortwave Radiation;;surface_direct_downwelling_shortwave_flux_in air;;;
-rsus;rsus;rsus;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upwelling Shortwave Radiation;;surface_upwelling_shortwave_flux_in_air;up;atmos;
-rlus;rlus;rlus;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upwelling Longwave Radiation;;surface_upwelling_longwave_flux_in_air;up;atmos;
-rlut;rlut;rlut;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;TOA Outgoing Longwave Radiation;;toa_outgoing_longwave_flux;up;atmos;
-rsdt;rsdt;rsdt;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;TOA Incident Shortwave Radiation;;toa_incoming_shortwave_flux;down;atmos;
-rsut;rsut;rsut;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;TOA Outgoing Shortwave Radiation;;toa_outgoing_shortwave_flux;up;atmos;
-hfls;hfls;hfls;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upward Latent Heat Flux;;surface_upward_latent_heat_flux;up;atmos;
-hfss;hfss;hfss;;;ModelLevel;1;;mean;mean;mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upward Sensible Heat Flux;;surface_upward_sensible_heat_flux;up;atmos;
-mrfso;mrfso;mrfso;;;ModelLevel;1;;point;mean;mean;;0;kg m-2;;4;i;1;;1;;;;;Soil Frozen Water Content;The mass of frozen water per unit area, summed over all soil layers. Reported as missing for grid cells with no land. Max depth: 12m;soil_frozen_water_content;;land landIce;mean where land
-mrfsos;mrfsos;mrfsos;Sum(mrsfl_L01:L03);;ModelLevel;1;;point;mean;mean;;0;kg m-2;;24;i;1;;1;;;;;Frozen Water Content in Upper Portion of Soil Column;The mass of frozen water in the upper 10cm of the soil layer. Reported as missing for grid cells with no land.;frozen_water_content_of_soil_layer;;land landIce;mean where land
-mrsfl;mrsfl;mrsfl;mrsfl_L01:L14;;ModelLevel;1;;point;mean;mean;;0;kg m-2;;4;i;1;;1;;;;;Frozen Water Content of Soil Layer;The mass of frozen water in each soil layer. Reported as missing for grid cells with no land.;frozen_water_content_of_soil_layer;;land landIce;mean where land
-mrso;mrso;mrso;;;ModelLevel;1;;point;mean;mean;;0;kg m-2;;4;i;1;;1;;;;;Total Soil Moisture Content;The mass of water in all phases per unit area, summed over all soil layers. Reported as missing for grid cells with no land. Max depth: 12m;mass_content_of_water_in_soil;;land;mean where land
-mrsos;mrsos;mrsos;Sum(mrsol_L01:L03);;ModelLevel;1;;point;mean;mean;;0;kg m-2;;24;i;1;;1;;;;;Moisture in Upper Portion of Soil Column;The mass of water in all phases in the upper 10cm of the soil layer. Reported as missing for grid cells with no land.;mass_content_of_water_in_soil_layer;;land;mean where land
-mrsol;mrsol;mrsol;mrsol_L01:L14;;ModelLevel;1;;point;mean;mean;;0;kg m-2;;4;i;1;;1;;;;;Total Water Content of Soil Layer;The mass of water in all phases in each soil layer. Reported as missing for grid cells with no land.;mass_content_of_water_in_soil_layer;;land;mean where land
-snw;snw;snw;;;ModelLevel;1;;point;mean;mean;;0;kg m-2;;4;i;1;;1;;;;;Surface Snow Amount;;surface_snow_amount;;landIce land;mean where land
-snc;snc;snc;;;ModelLevel;1;;point;mean;mean;;0;%;;4;i;1;;1;;;;;Snow Area Percentage;;surface_snow_area_fraction;;landIce land;
-snd;snd;snd;;;ModelLevel;1;;point;mean;mean;;0;m;;4;i;1;;1;;;;;Snow Depth;;surface_snow_thickness;;landIce land;mean where land
-siconca;siconca;siconca;;;ModelLevel;1;;;mean;mean;;0;%;;;i;1;;1;;;;;Sea-Ice Area Percentage (Atmospheric Grid);;sea_ice_area_fraction;;seaIce ocean;
-zmla;zmla;zmla;;;ModelLevel;1;;point;mean;mean;;0;m;;24;i;1;;1;;;;;Height of Boundary Layer;;atmosphere_boundary_layer_thickness;;atmos;
-prw;prw;prw;;;ModelLevel;1;;point;mean;mean;;0;kg m-2;;4;i;1;;1;;;;;Water Vapor Path;;atmosphere_mass_content_of_water_vapor;;atmos;
-clwvi;clwvi;clwvi;clqvi + clivi;;ModelLevel;1;;point;mean;mean;;0;kg m-2;;4;i;1;;1;;;;;Condensed Water Path;;atmosphere_mass_content_of_cloud_condensed_water;;atmos;
-clivi;clivi;clivi;;;ModelLevel;1;;point;mean;mean;;0;kg m-2;;4;i;1;;1;;;;;Ice Water Path;;atmosphere_mass_content_of_cloud_ice;;atmos;
-ua1000;ua1000;ua1000;;;PressureLevel;1;;point;mean;mean;;100000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua925;ua925;ua925;;;PressureLevel;1;;point;mean;mean;;92500;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua850;ua850;ua850;;;PressureLevel;1;;point;mean;mean;;85000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua700;ua700;ua700;;;PressureLevel;1;;point;mean;mean;;70000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua600;ua600;ua600;;;PressureLevel;1;;point;mean;mean;;60000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua500;ua500;ua500;;;PressureLevel;1;;point;mean;mean;;50000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua400;ua400;ua400;;;PressureLevel;1;;point;mean;mean;;40000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua300;ua300;ua300;;;PressureLevel;1;;point;mean;mean;;30000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua250;ua250;ua250;;;PressureLevel;1;;point;mean;mean;;25000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-ua200;ua200;ua200;;;PressureLevel;1;;point;mean;mean;;20000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
-va1000;va1000;va1000;;;PressureLevel;1;;point;mean;mean;;100000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va925;va925;va925;;;PressureLevel;1;;point;mean;mean;;92500;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va850;va850;va850;;;PressureLevel;1;;point;mean;mean;;85000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va700;va700;va700;;;PressureLevel;1;;point;mean;mean;;70000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va600;va600;va600;;;PressureLevel;1;;point;mean;mean;;60000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va500;va500;va500;;;PressureLevel;1;;point;mean;mean;;50000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va400;va400;va400;;;PressureLevel;1;;point;mean;mean;;40000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va300;va300;va300;;;PressureLevel;1;;point;mean;mean;;30000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va250;va250;va250;;;PressureLevel;1;;point;mean;mean;;25000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-va200;va200;va200;;;PressureLevel;1;;point;mean;mean;;20000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
-ta1000;ta1000;ta1000;;;PressureLevel;1;;point;mean;mean;;100000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta925;ta925;ta925;;;PressureLevel;1;;point;mean;mean;;92500;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta850;ta850;ta850;;;PressureLevel;1;;point;mean;mean;;85000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta700;ta700;ta700;;;PressureLevel;1;;point;mean;mean;;70000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta600;ta600;ta600;;;PressureLevel;1;;point;mean;mean;;60000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta500;ta500;ta500;;;PressureLevel;1;;point;mean;mean;;50000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta400;ta400;ta400;;;PressureLevel;1;;point;mean;mean;;40000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta300;ta300;ta300;;;PressureLevel;1;;point;mean;mean;;30000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta250;ta250;ta250;;;PressureLevel;1;;point;mean;mean;;25000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-ta200;ta200;ta200;;;PressureLevel;1;;point;mean;mean;;20000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
-hus1000;hus1000;hus1000;;;PressureLevel;1;;point;mean;mean;;100000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus925;hus925;hus925;;;PressureLevel;1;;point;mean;mean;;92500;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus850;hus850;hus850;;;PressureLevel;1;;point;mean;mean;;85000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus700;hus700;hus700;;;PressureLevel;1;;point;mean;mean;;70000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus600;hus600;hus600;;;PressureLevel;1;;point;mean;mean;;60000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus500;hus500;hus500;;;PressureLevel;1;;point;mean;mean;;50000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus400;hus400;hus400;;;PressureLevel;1;;point;mean;mean;;40000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus300;hus300;hus300;;;PressureLevel;1;;point;mean;mean;;30000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus250;hus250;hus250;;;PressureLevel;1;;point;mean;mean;;25000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-hus200;hus200;hus200;;;PressureLevel;1;;point;mean;mean;;20000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
-zg1000;zg1000;zg1000;;;PressureLevel;1;;point;mean;mean;;100000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_1000hPa;geopotential_height;;atmos;
-zg925;zg925;zg925;;;PressureLevel;1;;point;mean;mean;;92500;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_925hPa;geopotential_height;;atmos;
-zg850;zg850;zg850;;;PressureLevel;1;;point;mean;mean;;85000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_850hPa;geopotential_height;;atmos;
-zg700;zg700;zg700;;;PressureLevel;1;;point;mean;mean;;70000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_700hPa;geopotential_height;;atmos;
-zg600;zg600;zg600;;;PressureLevel;1;;point;mean;mean;;60000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_600hPa;geopotential_height;;atmos;
-zg500;zg500;zg500;;;PressureLevel;1;;point;mean;mean;;50000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_500hPa;geopotential_height;;atmos;
-zg400;zg400;zg400;;;PressureLevel;1;;point;mean;mean;;40000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_400hPa;geopotential_height;;atmos;
-zg300;zg300;zg300;;;PressureLevel;1;;point;mean;mean;;30000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_300hPa;geopotential_height;;atmos;
-zg250;zg250;zg250;;;PressureLevel;1;;point;mean;mean;;25000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_250hPa;geopotential_height;;atmos;
-zg200;zg200;zg200;;;PressureLevel;1;;point;mean;mean;;20000;m;;4;i;1;;1;;;;;Geopotential Height;geopotential_height_at_200hPa;geopotential_height;;atmos;
-ua100m;ua100m;ua100m;;;ModelLevel;1;;point;mean;mean;;100;m s-1;;24;i;1;;1;;;;;Eastward wind at 100 m;;eastward_wind;;atmos;
-va100m;va100m;va100m;;;ModelLevel;1;;point;mean;mean;;100;m s-1;;24;i;1;;1;;;;;Northward wind at 100 m;;northward_wind;;atmos;
-ua150m;ua150m;ua150m;;;ModelLevel;1;;point;mean;mean;;150;m s-1;;24;i;1;;1;;;;;Eastward wind at 150 m;;eastward_wind;;atmos;
-va150m;va150m;va150m;;;ModelLevel;1;;point;mean;mean;;150;m s-1;;24;i;1;;1;;;;;Northward wind at 150 m;;northward_wind;;atmos;
-ua50m;ua50m;ua50m;;;ModelLevel;1;;point;mean;mean;;50;m s-1;;24;i;1;;1;;;;;Eastward wind at 50 m;;eastward_wind;;atmos;
-va50m;va50m;va50m;;;ModelLevel;1;;point;mean;mean;;50;m s-1;;24;i;1;;1;;;;;Northward wind at 50 m;;northward_wind;;atmos;
-ta50m;ta50m;ta50m;;;ModelLevel;1;;point;mean;mean;;50;K;;24;i;1;;1;;;;;Air Temperature at 50m;;air_temperature;;atmos;
-hus50m;hus50m;hus50m;;;ModelLevel;1;;point;mean;mean;;50;1;;24;i;1;;1;;;;;Specific Humidity at 50m;;specific_humidity;;atmos;
-z0;z0;z0;;;ModelLevel;1;; ;maximum;maximum within days time: mean over days;;0;m;;;i;1;;1;;;;;Surface Roughness Length;;surface_roughness_length;;;
-cape;cape;cape;;;ModelLevel;1;;;maximum;;;0;J kg-1;;;a;1;;;;;;;2-D Convective Available Potential Energy;;atmosphere_convective_available_potential_energy_wrt_surface;;atmos;
-ua300m;ua300m;ua300m;;;ModelLevel;1;;point;mean;mean;;300;m s-1;;24;i;1;;1;;;;;Eastward wind at 300 m;;eastward_wind;;atmos;
-va300m;va300m;va300m;;;ModelLevel;1;;point;mean;mean;;300;m s-1;;24;i;1;;1;;;;;Northward wind at 300 m;;northward_wind;;atmos;
-sftgif;sftgif;sftgif;;;;1;;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Covered by Glacier;;land_ice_area_fraction;;;
-sftlaf;sftlaf;sftlaf;;;;1;;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Occupied by Lake;;lake_area_fraction;;;
-sfturf;sfturf;sfturf;;;;1;;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Occupied by City;;urban_area_fraction;;;
-areacella;areacella;areacella;;;;1;;;;;;;m2;;;;;;;;;;0;Atmosphere Grid-Cell Area;;cell_area;;;
+tas;tas;tas;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;2;K;;24;i;1;;1;;;;;Near-Surface Air Temperature;;air_temperature;;atmos;
+tasmax;tasmax;tasmax;;;ModelLevel;1;;;area: mean time: maximum;area: mean time: maximum within days time: mean over days;;2;K;;;a;1;;1;;;;;Daily Maximum Near-Surface Air Temperature;maximum from all integrated time steps per day;air_temperature;;atmos;
+tasmin;tasmin;tasmin;;;ModelLevel;1;;;area: mean time: minimum;area: mean time: minimum within days time: mean over days;;2;K;;;a;1;;1;;;;;Daily Minimum Near-Surface Air Temperature;minimum from all integrated time steps per day;air_temperature;;atmos;
+pr;pr;pr;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;kg m-2 s-1;;24;a;1;;1;;;;;Precipitation;;precipitation_flux;;atmos;
+ps;ps;ps;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;Pa;;24;i;1;;1;;;;;Surface Air Pressure;;surface_air_pressure;;atmos;
+evspsbl;evspsbl;evspsbl;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;kg m-2 s-1;;24;a;1;;1;;;;;Evaporation Including Sublimation and Transpiration;;water_evapotranspiration_flux;;atmos;
+huss;huss;huss;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;2;1;;24;i;1;;1;;;;;Near-Surface Specific Humidity;;specific_humidity;;atmos;
+hurs;hurs;hurs;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;2;%;;24;i;1;;1;;;;;Near-Surface Relative Humidity;;relative_humidity;;atmos;
+psl;psl;psl;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;Pa;;24;i;1;;1;;;;;Sea Level Pressure;;air_pressure_at_mean_sea_level;;atmos;
+sfcWind;sfcWind;sfcWind;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;10;m s-1;;24;i;1;;1;;;;;Near-Surface Wind Speed;;wind_speed;;atmos;
+uas;uas;uas;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;10;m s-1;;24;i;1;;1;;;;;Eastward Near-Surface Wind;;eastward_wind;;atmos;
+vas;vas;vas;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;10;m s-1;;24;i;1;;1;;;;;Northward Near-Surface Wind;;northward_wind;;atmos;
+clt;clt;clt;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;%;;24;a;1;;1;;;;;Total Cloud Cover Percentage;;cloud_area_fraction;;atmos;
+rsds;rsds;rsds;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Downwelling Shortwave Radiation;;surface_downwelling_shortwave_flux_in_air;down;atmos;
+rlds;rlds;rlds;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Downwelling Longwave Radiation;;surface_downwelling_longwave_flux_in_air;down;atmos;
+orog;orog;orog;;;;1;area: mean;;;;;;m;;;;;;;;;;0;Surface Altitude;;surface_altitude;;atmos;
+sftlf;sftlf;sftlf;sftnf + sfturf;;;1;area: mean;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Occupied by Land;;land_area_fraction;;atmos;
+ts;ts;ts;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;K;;24;i;1;;1;;;;;Surface Temperature;;surface_temperature;;atmos;
+tsl;tsl;tsl;tsl_L01:L14;;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;K;;4;i;1;;1;;;;;Temperature of Soil;Temperature of each soil layer (3D variable). Reported as missing for grid cells with no land.;soil_temperature;;land;mean where land
+prc;prc;prc;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;kg m-2 s-1;;24;a;1;;1;;;;;Convective Precipitation;;convective_precipitation_flux;;atmos;
+prhmax;prhmax;prhmax;daymax(pr);;ModelLevel;1;;;area: mean time: mean within hours time: maximum over hours;area: mean time: mean within hours time: maximum over hours;;0;kg m-2 s-1;;;a;1;;1;;;;;Daily Maximum Hourly Precipitation Rate;Defined as maximum of the precipitation rate averaged over the whole hour.;precipitation_flux;;atmos;
+prsn;prsn;prsn;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;kg m-2 s-1;;24;a;1;;1;;;;;Snowfall Flux;;snowfall_flux;;atmos;
+mrros;mrros;mrros;;;ModelLevel;;;area: mean where land time: mean;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Surface Runoff;;surface_runoff_flux;;land;mean where land
+mrro;mrro;mrro;mrrod + mrros;;ModelLevel;;;area: mean where land time: mean;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Total Runoff;;runoff_flux;;land;mean where land
+snm;snm;snm;;;ModelLevel;;;area: mean where land time: mean;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Surface Snow Melt;;surface_snow_melt_flux;;landIce land;mean where land
+tauu;tauu;tauu;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;Pa;;4;a;1;;1;;;;;Surface Downward Eastward Wind Stress;;surface_downward_eastward_stress;down;atmos;
+tauv;tauv;tauv;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;Pa;;4;a;1;;1;;;;;Surface Downward Northward Wind Stress;;surface_downward_northward_stress;down;atmos;
+sfcWindmax;sfcWindmax;sfcWindmax;;;ModelLevel;1;;;area: mean time: maximum;area: mean time: maximum within days time: mean over days;;10;m s-1;;;a;1;;1;;;;;Daily Maximum Near-Surface Wind Speed;Maximum from all integrated time steps per day;wind_speed;;atmos;
+wsgsmax;wsgsmax;wsgsmax;;;ModelLevel;1;;;area: mean time: maximum;area: mean time: maximum within days time: mean over days;;10;m s-1;;8;a;1;;1;;;;;Daily Maximum Near-Surface Wind Speed of Gust;;wind_speed_of_gust;;atmos;
+sund;sund;sund;;;ModelLevel;1;;;time: sum;time: sum within days time: mean over days;;0;s;;;a;1;;1;;;;;Daily Duration of Sunshine;"The WMO definition of sunshine is that the surface incident radiative flux from the solar beam (i.e. excluding diffuse skylight) exceeds 120 W m-2. ""Duration"" is the length of time for which a condition holds.";duration_of_sunshine;;atmos;
+rsdsdir;rsdsdir;rsdsdir;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Direct Downwelling Shortwave Radiation;;surface_direct_downwelling_shortwave_flux_in_air;;;
+rsus;rsus;rsus;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upwelling Shortwave Radiation;;surface_upwelling_shortwave_flux_in_air;up;atmos;
+rlus;rlus;rlus;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upwelling Longwave Radiation;;surface_upwelling_longwave_flux_in_air;up;atmos;
+rlut;rlut;rlut;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Outgoing Longwave Radiation;;toa_outgoing_longwave_flux;up;atmos;
+rsdt;rsdt;rsdt;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Incident Shortwave Radiation;;toa_incoming_shortwave_flux;down;atmos;
+rsut;rsut;rsut;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Outgoing Shortwave Radiation;;toa_outgoing_shortwave_flux;up;atmos;
+hfls;hfls;hfls;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upward Latent Heat Flux;;surface_upward_latent_heat_flux;up;atmos;
+hfss;hfss;hfss;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upward Sensible Heat Flux;;surface_upward_sensible_heat_flux;up;atmos;
+mrfso;mrfso;mrfso;;;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2;;4;i;1;;1;;;;;Soil Frozen Water Content;The mass of frozen water per unit area, summed over all soil layers. Reported as missing for grid cells with no land.;soil_frozen_water_content;;land landIce;mean where land
+mrfsos;mrfsos;mrfsos;Sum(mrsfl_L01:L03);;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;kg m-2;;24;i;1;;1;;;;;Frozen Water Content in Upper Portion of Soil Column;The mass of frosen water  in the upper 10cm of the soil layer. Reported as missing for grid cells with no land. (not in CMIP);frozen_water_content_of_soil_layer;;land landIce;mean where land
+mrsfl;mrsfl;mrsfl;mrsfl_L01:L14;;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2;;4;i;1;;1;;;;;Frozen Water Content of Soil Layer;The mass of frosen water in each soil layer (3D variable). Reported as missing for grid cells with no land. (not in CMIP) [mrfsol -> mrsfl, 2022.09.22, https://github.com/WCRP-CORDEX/cordex-cmip6-data-request/issues/2 ];frozen_water_content_of_soil_layer;;land landIce;mean where land
+mrso;mrso;mrso;;;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2;;4;i;1;;1;;;;;Total Soil Moisture Content;The mass of water in all phases per unit area, summed over all soil layers.;mass_content_of_water_in_soil;;land;mean where land
+mrsos;mrsos;mrsos;Sum(mrsol_L01:L03);;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2;;24;i;1;;1;;;;;Moisture in Upper Portion of Soil Column;The mass of water in all phases in the upper 10cm of the soil layer. Reported as missing for grid cells with no land.;mass_content_of_water_in_soil_layer;;land;mean where land
+mrsol;mrsol;mrsol;mrsol_L01:L14;;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2;;4;i;1;;1;;;;;Total Water Content of Soil Layer;The mass of water in all phases in each soil layer (3D variable). Reported as missing for grid cells with no land.;mass_content_of_water_in_soil_layer;;land;mean where land
+snw;snw;snw;;;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2;;4;i;1;;1;;;;;Surface Snow Amount;;surface_snow_amount;;landIce land;mean where land
+snc;snc;snc;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;%;;4;i;1;;1;;;;;Snow Area Percentage;;surface_snow_area_fraction;;landIce land;
+snd;snd;snd;;;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;m;;4;i;1;;1;;;;;Snow Depth;;surface_snow_thickness;;landIce land;mean where land
+siconca;siconca;siconca;;;ModelLevel;1;;;area: time: mean;area: time: mean;;0;%;;;i;1;;1;;;;;Sea-Ice Area Percentage (Atmospheric Grid);daily and monthly means;sea_ice_area_fraction;;seaIce ocean;
+zmla;zmla;zmla;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;m;;24;i;1;;1;;;;;Height of Boundary Layer;;atmosphere_boundary_layer_thickness;;atmos;
+prw;prw;prw;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;kg m-2;;4;i;1;;1;;;;;Water Vapor Path;;atmosphere_mass_content_of_water_vapor;;atmos;
+clwvi;clwvi;clwvi;clqvi + clivi;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;kg m-2;;4;i;1;;1;;;;;Condensed Water Path;;atmosphere_mass_content_of_cloud_condensed_water;;atmos;
+clivi;clivi;clivi;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;kg m-2;;4;i;1;;1;;;;;Ice Water Path;;atmosphere_mass_content_of_cloud_ice;;atmos;
+ua1000;ua1000;ua1000;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;100000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua925;ua925;ua925;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;92500;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua850;ua850;ua850;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;85000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua700;ua700;ua700;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;70000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua600;ua600;ua600;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;60000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua500;ua500;ua500;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua400;ua400;ua400;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;40000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua300;ua300;ua300;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;30000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua250;ua250;ua250;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;25000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+ua200;ua200;ua200;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;20000;m s-1;;4;i;1;;1;;;;;Eastward Wind;;eastward_wind;;atmos;
+va1000;va1000;va1000;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;100000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va925;va925;va925;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;92500;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va850;va850;va850;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;85000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va700;va700;va700;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;70000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va600;va600;va600;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;60000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va500;va500;va500;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va400;va400;va400;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;40000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va300;va300;va300;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;30000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va250;va250;va250;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;25000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+va200;va200;va200;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;20000;m s-1;;4;i;1;;1;;;;;Northward Wind;;northward_wind;;atmos;
+ta1000;ta1000;ta1000;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;100000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta925;ta925;ta925;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;92500;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta850;ta850;ta850;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;85000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta700;ta700;ta700;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;70000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta600;ta600;ta600;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;60000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta500;ta500;ta500;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta400;ta400;ta400;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;40000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta300;ta300;ta300;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;30000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta250;ta250;ta250;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;25000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+ta200;ta200;ta200;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;20000;K;;4;i;1;;1;;;;;Air Temperature;;air_temperature;;atmos;
+hus1000;hus1000;hus1000;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;100000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus925;hus925;hus925;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;92500;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus850;hus850;hus850;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;85000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus700;hus700;hus700;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;70000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus600;hus600;hus600;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;60000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus500;hus500;hus500;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus400;hus400;hus400;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;40000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus300;hus300;hus300;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;30000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus250;hus250;hus250;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;25000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+hus200;hus200;hus200;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;20000;1;;4;i;1;;1;;;;;Specific Humidity;;specific_humidity;;atmos;
+zg1000;zg1000;zg1000;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;100000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg925;zg925;zg925;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;92500;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg850;zg850;zg850;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;85000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg700;zg700;zg700;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;70000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg600;zg600;zg600;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;60000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg500;zg500;zg500;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg400;zg400;zg400;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;40000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg300;zg300;zg300;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;30000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg250;zg250;zg250;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;25000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+zg200;zg200;zg200;;;PressureLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;20000;m;;4;i;1;;1;;;;;Geopotential Height;;geopotential_height;;atmos;
+ua100m;ua100m;ua100m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;100;m s-1;;24;i;1;;1;;;;;Eastward Wind at 100m;;eastward_wind;;atmos;
+va100m;va100m;va100m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;100;m s-1;;24;i;1;;1;;;;;Northward Wind at 100m;;northward_wind;;atmos;
+ua150m;ua150m;ua150m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;150;m s-1;;24;i;1;;1;;;;;Eastward Wind at 150m;;eastward_wind;;atmos;
+va150m;va150m;va150m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;150;m s-1;;24;i;1;;1;;;;;Northward Wind at 150m;;northward_wind;;atmos;
+ua50m;ua50m;ua50m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50;m s-1;;24;i;1;;1;;;;;Eastward Wind at 50m;;eastward_wind;;atmos;
+va50m;va50m;va50m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50;m s-1;;24;i;1;;1;;;;;Northward Wind at 50m;;northward_wind;;atmos;
+ta50m;ta50m;ta50m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50;K;;24;i;1;;1;;;;;Air Temperature at 50m;requested for urban modeling;air_temperature;;atmos;
+hus50m;hus50m;hus50m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50;1;;24;i;1;;1;;;;;Specific Humidity at 50m;requested for urban modeling;specific_humidity;;atmos;
+z0;z0;z0;;;ModelLevel;1;;;area: time: mean;area: time: mean;;0;m;;;i;1;;1;;;;;Surface Roughness Length;;surface_roughness_length;;;
+cape;cape;cape;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;J kg-1;;;a;1;;;;;;;Convective Available Potential Energy;;atmosphere_convective_available_potential_energy_wrt_surface;;atmos;
+ua300m;ua300m;ua300m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;300;m s-1;;24;i;1;;1;;;;;Eastward Wind at 250m;;eastward_wind;;atmos;
+va300m;va300m;va300m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;300;m s-1;;24;i;1;;1;;;;;Northward Wind at 350m;;northward_wind;;atmos;
+sftgif;sftgif;sftgif;;;;1;area: mean;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Covered by Glacier;;land_ice_area_fraction;;;
+sftlaf;sftlaf;sftlaf;;;;1;area: mean where fresh_free_water;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Occupied by Lake;not in CMIP or in CF;area_fraction;;;
+sfturf;sfturf;sfturf;;;;1;area: mean where urban;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Occupied by Urban Area;not in CMIP or in CF;area_fraction;;;
+areacella;areacella;areacella;;;;1;area: sum;;;;;;m2;;;;;;;;;;0;Atmosphere Grid-Cell Area;;cell_area;;;

--- a/src/CMORlight/tools.py
+++ b/src/CMORlight/tools.py
@@ -854,6 +854,15 @@ def process_file_fix(params,in_file):
     f_var.standard_name = settings.netCDF_attributes['standard_name']
     f_var.long_name = settings.netCDF_attributes['long_name']
     f_var.units = settings.netCDF_attributes['units']
+
+    cm_type = params[config.get_config_value('index', 'INDEX_VAR_CM_ASU')]
+    if cm_type:
+        f_var.cell_methods = cm_type
+
+    comment = params[config.get_config_value('index', 'INDEX_VAR_COMMENT')]
+    if comment != "":
+        f_var.comment = comment
+
     #add coordinates attribute to fx-variables
     f_var.coordinates = 'lon lat'
 

--- a/src/CMORlight/tools.py
+++ b/src/CMORlight/tools.py
@@ -1420,7 +1420,7 @@ is here the time resolution of the input data in hours."
         ftmp_name = "%s/%s-%s-%s.nc" % (settings.DirWork,year,str(uuid.uuid1()),var)
 
         # get type of cell method to create the output file: point,mean,maximum,minimum,sum
-        cm = cm_type
+        cm = cm_type[cm_type.find("time: ") + len("time: "):]
         
         #for monthly resolution: determine cell method within days time
         if res == 'mon' and 'within days time' in cm_type:
@@ -1696,7 +1696,7 @@ is here the time resolution of the input data in hours."
         f_var.standard_name = settings.netCDF_attributes['standard_name']
         f_var.long_name = settings.netCDF_attributes['long_name']
         f_var.units = settings.netCDF_attributes['units']
-        f_var.cell_methods = "time: %s" % (cm_type)
+        f_var.cell_methods = cm_type
 
         #HJP Mar 2019 Begin
         #include variable's attribute "comment" if the corresponding entry in the csv-file is not empty

--- a/src/devutil/vartable_update.py
+++ b/src/devutil/vartable_update.py
@@ -5,11 +5,13 @@ import json
 import pooch
 import pathlib
 
+INDEX_VAR_CM_ASU = 7
 INDEX_VAR_CM_SUB = 8
 INDEX_VAR_CM_DAY = 9
 INDEX_VAR_CM_MON = 10
 INDEX_UNIT = 13
 INDEX_VAR_LONG_NAME = 24
+INDEX_VAR_COMMENT = 25
 INDEX_VAR_STD_NAME = 26
 
 
@@ -77,6 +79,14 @@ def main():
         else:
             row[INDEX_VAR_CM_MON] = ""
 
+        # For fx variables, we place cell_method in the additional subdaily
+        # column (currently not used by any other type of var).
+        #
+        if var in cmor_tables["fx"]:
+            row[INDEX_VAR_CM_ASU] = cmor_tables["fx"][var]["cell_methods"]
+        else:
+            row[INDEX_VAR_CM_ASU] = ""
+
         # units, long_name and standard_name
         #
         if var in cmor_tables["day"]:
@@ -88,6 +98,7 @@ def main():
 
         row[INDEX_UNIT] = var_info["units"]
         row[INDEX_VAR_LONG_NAME] = var_info["long_name"]
+        row[INDEX_VAR_COMMENT] = var_info["comment"]
         row[INDEX_VAR_STD_NAME] = var_info["standard_name"]
 
     # Save generated table to csv

--- a/src/devutil/vartable_update.py
+++ b/src/devutil/vartable_update.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+import csv
+import json
+import pooch
+import pathlib
+
+INDEX_VAR_CM_SUB = 8
+INDEX_VAR_CM_DAY = 9
+INDEX_VAR_CM_MON = 10
+INDEX_UNIT = 13
+INDEX_VAR_LONG_NAME = 24
+INDEX_VAR_STD_NAME = 26
+
+
+def main():
+    cmor_table_files = {
+        "1hr": "CORDEX-CMIP6_1hr.json",
+        "6hr": "CORDEX-CMIP6_6hr.json",
+        "day": "CORDEX-CMIP6_day.json",
+        "mon": "CORDEX-CMIP6_mon.json",
+        "fx": "CORDEX-CMIP6_fx.json",
+    }
+
+    # Let pooch deal with downloading and caching cmor table files
+    #
+    cmor_table_file_manager = pooch.create(
+        path=pooch.os_cache("hclim2cmor"),
+        base_url="https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables/raw/main/Tables",
+        registry={f: None for f in cmor_table_files.values()},
+    )
+    cmor_tables = {}
+    for freq, file in cmor_table_files.items():
+        table_file_path = cmor_table_file_manager.fetch(file)
+        with open(table_file_path) as f:
+            cmor_tables[freq] = json.load(f)["variable_entry"]
+
+    # Load current csv
+    #
+    csv_path = (
+        pathlib.Path(__file__).parent.parent
+        / "CMORlight"
+        / "Config"
+        / "CORDEX6_CMOR_HCLIM_variables_table.csv"
+    )
+    table = []
+    with open(csv_path, newline="") as f:
+        reader = csv.reader(f, delimiter=";")
+        for row in reader:
+            table.append(row)
+
+    # Fetch and insert values from cmor tables
+    #
+    for row in table[1:]:
+        var = row[0]
+
+        # Subdaily cell method
+        #
+        if var in cmor_tables["1hr"]:
+            row[INDEX_VAR_CM_SUB] = cmor_tables["1hr"][var]["cell_methods"]
+        elif var in cmor_tables["6hr"]:
+            row[INDEX_VAR_CM_SUB] = cmor_tables["6hr"][var]["cell_methods"]
+        else:
+            row[INDEX_VAR_CM_SUB] = ""
+
+        # Daily cell method
+        #
+        if var in cmor_tables["day"]:
+            row[INDEX_VAR_CM_DAY] = cmor_tables["day"][var]["cell_methods"]
+        else:
+            row[INDEX_VAR_CM_DAY] = ""
+
+        # Monthly cell_method
+        #
+        if var in cmor_tables["mon"]:
+            row[INDEX_VAR_CM_MON] = cmor_tables["mon"][var]["cell_methods"]
+        else:
+            row[INDEX_VAR_CM_MON] = ""
+
+        # units, long_name and standard_name
+        #
+        if var in cmor_tables["day"]:
+            var_info = cmor_tables["day"][var]
+        elif var in cmor_tables["fx"]:
+            var_info = cmor_tables["fx"][var]
+        else:
+            raise KeyError("Couldn't find information about variable")
+
+        row[INDEX_UNIT] = var_info["units"]
+        row[INDEX_VAR_LONG_NAME] = var_info["long_name"]
+        row[INDEX_VAR_STD_NAME] = var_info["standard_name"]
+
+    # Save generated table to csv
+    #
+    with open(csv_path, "w") as f:
+        writer = csv.writer(f, delimiter=";", lineterminator="\n")
+        writer.writerows(table)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #22 

I've made a first attempt to update the variables table from the github cmor tables. I took a slightly different approach than I originally planned: instead of generating a new table, the current table is read and updated. This means there should already be a row for each variable, with all required columns filled out, except for the columns that are updated from the cmor tables.

Currently only the following columns are updated:
- `Cell Method (subdaily,CORDEX)` from `cell_methods` of either `1hr` or `6hr` table
- `Cell Method (daily,CORDEX)` from `cell_methods` of `day` table
- `Cell Method (monthly,CORDEX)` from `cell_methods` of `mon` table
- `units`, `long_name` and `standard_name` from `day` or `fx` table, depending on where the variable is found.

I've updated the table using the update script, please look at the updated table in the PR.

1. Are there more columns that should be updated?
2. Should `fx` variables have a value for `cell_methods`? (unsure where to put it in the table)
