### PR TITLE
Updating config: ERA5 driving_experiment

### DIFF
--- a/config/simulation_config.yml
+++ b/config/simulation_config.yml
@@ -24,7 +24,7 @@ simulations:
     name_tag: "EUR11_EUR11_ALADIN43_v1_ERA5_r1i1p1f1_eval"
     driving_source_id: "ERA5"
     driving_experiment_id: "evaluation"
-    driving_experiment: "reanalysis"
+    driving_experiment: "reanalysis simulation of the recent past"
     driving_variant_label: "r1i1p1f1"
     driving_institution_id: "ECMWF"
     domain: "Europe"


### PR DESCRIPTION
Updating `driving_experiment` value of ERA5 config, to comply with CV.