### PR TITLE
Wrapper and table fixes

### DIFF
--- a/src/CMORlight/Config/CORDEX6_CMOR_HCLIM_variables_table.csv
+++ b/src/CMORlight/Config/CORDEX6_CMOR_HCLIM_variables_table.csv
@@ -31,17 +31,17 @@ prsn;prsn;prsn;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mea
 mrros;mrros;mrros;;;ModelLevel;;;area: mean where land time: mean;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Surface Runoff;;surface_runoff_flux;;land;mean where land
 mrro;mrro;mrro;mrrod + mrros;;ModelLevel;;;area: mean where land time: mean;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Total Runoff;;runoff_flux;;land;mean where land
 snm;snm;snm;;;ModelLevel;;;area: mean where land time: mean;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2 s-1;;4;a;1;;1;;;;;Surface Snow Melt;;surface_snow_melt_flux;;landIce land;mean where land
-tauu;tauu;tauu;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;Pa;;24;a;1;;1;;;;;Surface Downward Eastward Wind Stress;;surface_downward_eastward_stress;;atmos;
-tauv;tauv;tauv;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;Pa;;24;a;1;;1;;;;;Surface Downward Northward Wind Stress;;surface_downward_northward_stress;;atmos;
+tauu;tauu;tauu;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;Pa;;24;a;1;;1;;;;;Surface Downward Eastward Wind Stress;;surface_downward_eastward_stress;down;atmos;
+tauv;tauv;tauv;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;Pa;;24;a;1;;1;;;;;Surface Downward Northward Wind Stress;;surface_downward_northward_stress;down;atmos;
 sfcWindmax;sfcWindmax;sfcWindmax;;;ModelLevel;1;;;area: mean time: maximum;area: mean time: maximum within days time: mean over days;;10;m s-1;;;a;1;;1;;;;;Daily Maximum Near-Surface Wind Speed;Maximum from all integrated time steps per day;wind_speed;;atmos;
 wsgsmax;wsgsmax;wsgsmax;;;ModelLevel;1;;;area: mean time: maximum;area: mean time: maximum within days time: mean over days;;10;m s-1;;;a;1;;1;;;;;Daily Maximum Near-Surface Wind Speed of Gust;;wind_speed_of_gust;;atmos;
 sund;sund;sund;;;ModelLevel;1;;;time: sum;time: sum within days time: mean over days;;0;s;;;a;1;;1;;;;;Daily Duration of Sunshine;"The WMO definition of sunshine is that the surface incident radiative flux from the solar beam (i.e. excluding diffuse skylight) exceeds 120 W m-2. ""Duration"" is the length of time for which a condition holds.";duration_of_sunshine;;atmos;
 rsdsdir;rsdsdir;rsdsdir;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Direct Downwelling Shortwave Radiation;;surface_direct_downwelling_shortwave_flux_in_air;down;;
 rsus;rsus;rsus;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upwelling Shortwave Radiation;;surface_upwelling_shortwave_flux_in_air;up;atmos;
 rlus;rlus;rlus;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upwelling Longwave Radiation;;surface_upwelling_longwave_flux_in_air;up;atmos;
-rlut;rlut;rlut;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Outgoing Longwave Radiation;;toa_outgoing_longwave_flux;;atmos;
-rsdt;rsdt;rsdt;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Incident Shortwave Radiation;;toa_incoming_shortwave_flux;;atmos;
-rsut;rsut;rsut;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Outgoing Shortwave Radiation;;toa_outgoing_shortwave_flux;;atmos;
+rlut;rlut;rlut;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Outgoing Longwave Radiation;;toa_outgoing_longwave_flux;up;atmos;
+rsdt;rsdt;rsdt;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Incident Shortwave Radiation;;toa_incoming_shortwave_flux;down;atmos;
+rsut;rsut;rsut;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;TOA Outgoing Shortwave Radiation;;toa_outgoing_shortwave_flux;up;atmos;
 hfls;hfls;hfls;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upward Latent Heat Flux;;surface_upward_latent_heat_flux;up;atmos;
 hfss;hfss;hfss;;;ModelLevel;1;;area: time: mean;area: time: mean;area: time: mean;;0;W m-2;;24;a;1;;1;;;;;Surface Upward Sensible Heat Flux;;surface_upward_sensible_heat_flux;up;atmos;
 mrfso;mrfso;mrfso;;;ModelLevel;1;;area: mean where land time: point;area: mean where land time: mean;area: mean where land time: mean;;0;kg m-2;;4;i;1;;1;;;;;Soil Frozen Water Content;The mass of frozen water per unit area, summed over all soil layers. Reported as missing for grid cells with no land.;soil_frozen_water_content;;land landIce;mean where land
@@ -118,8 +118,8 @@ ta50m;ta50m;ta50m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: 
 hus50m;hus50m;hus50m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;50;1;;24;i;1;;1;;;;;Specific Humidity at 50m;requested for urban modeling;specific_humidity;;atmos;
 z0;z0;z0;;;ModelLevel;1;;;area: time: mean;area: time: mean;;0;m;;;i;1;;1;;;;;Surface Roughness Length;;surface_roughness_length;;;
 cape;cape;cape;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;0;J kg-1;;24;a;1;;;;;;;Convective Available Potential Energy;;atmosphere_convective_available_potential_energy_wrt_surface;;atmos;
-ua300m;ua300m;ua300m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;300;m s-1;;24;i;1;;1;;;;;Eastward Wind at 250m;;eastward_wind;;atmos;
-va300m;va300m;va300m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;300;m s-1;;24;i;1;;1;;;;;Northward Wind at 350m;;northward_wind;;atmos;
+ua300m;ua300m;ua300m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;300;m s-1;;24;i;1;;1;;;;;Eastward Wind at 300m;;eastward_wind;;atmos;
+va300m;va300m;va300m;;;ModelLevel;1;;area: mean time: point;area: time: mean;area: time: mean;;300;m s-1;;24;i;1;;1;;;;;Northward Wind at 300m;;northward_wind;;atmos;
 sftgif;sftgif;sftgif;;;;1;area: mean;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Covered by Glacier;;land_ice_area_fraction;;;
 sftlaf;sftlaf;sftlaf;;;;1;area: mean where fresh_free_water;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Occupied by Lake;not in CMIP or in CF;area_fraction;;;
 sfturf;sfturf;sfturf;;;;1;area: mean where urban;;;;;;%;;;;;;;;;;0;Percentage of the Grid Cell Occupied by Urban Area;not in CMIP or in CF;area_fraction;;;

--- a/src/CMORlight/cmorlight.py
+++ b/src/CMORlight/cmorlight.py
@@ -365,7 +365,7 @@ def main():
         print("Create logging directory: %s" % LOG_BASE)
         os.makedirs(LOG_BASE, exist_ok=True)
     #LOG_FILENAME = os.path.join(LOG_BASE,'CMORlight.')+config.get_sim_value('driving_source_id')+"_"+config.get_sim_value('driving_experiment_id')+"."
-    LOG_FILENAME = os.path.join(LOG_BASE,'CMORlight.')+config.get_sim_value('driving_source_id')+"_"+config.get_sim_value('driving_experiment_id')+"_"+varlist[0]+"."
+    LOG_FILENAME = os.path.join(LOG_BASE,'CMORlight.')+config.get_sim_value('driving_source_id')+"_"+config.get_sim_value('driving_experiment_id')+"_"+"_".join(varlist)+"."
     logext = datetime.datetime.now().strftime("%d-%m-%Y")+'.log'
 
     # get logger and assign logging filename (many loggers for multiprocessing)

--- a/src/devutil/vartable_update.py
+++ b/src/devutil/vartable_update.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import csv
+import datetime
 import json
 import pooch
 import pathlib
@@ -26,10 +27,11 @@ def main():
         "fx": "CORDEX-CMIP6_fx.json",
     }
 
-    # Let pooch deal with downloading and caching cmor table files
+    # Let pooch deal with downloading cmor table files
     #
+    TIME_STAMP = datetime.datetime.now().strftime("%Y%m%d.%H%M%S")
     cmor_table_file_manager = pooch.create(
-        path=pooch.os_cache("hclim2cmor"),
+        path=pooch.os_cache("hclim2cmor") / TIME_STAMP,
         base_url="https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables/raw/main/Tables",
         registry={f: None for f in cmor_table_files.values()},
     )

--- a/src/master_wrapper.py
+++ b/src/master_wrapper.py
@@ -4,9 +4,7 @@ import argparse
 import datetime
 import os
 import subprocess
-import time
 import yaml
-from multiprocessing import Pool
 
 
 CONSTANT_VARIABLES = ["orog", "sftlf", "sftnf", "sfturf", "sftlaf"]
@@ -114,7 +112,7 @@ def run_constants(
     post_command = (
         f"sbatch -J post_C_{simulation}_{start_year}"
         f" -o {log_dir}/{log_file}"
-        f" master_post.sh -C"
+        f" master_post.sh -C -O"
     )
     post_process = subprocess.run(
         post_command, shell=True, capture_output=True, text=True
@@ -128,7 +126,7 @@ def run_constants(
         f" -d afterok:{post_job_id} -o {log_dir}/{log_file}"
         f" master_cmor.sh -i ../../control_cmor/{control_cmor} -m {simulation}"
         f" -M 10 -v {','.join(var_list)} -s {start_year} -e {end_year}"
-        f" -n latest -V"
+        f" -n latest -V -O"
     )
     cmor_process = subprocess.run(
         cmor_command, shell=True, capture_output=True, text=True
@@ -154,7 +152,7 @@ def run_post(
 
     post_command = (
         f"sbatch -J post_{simulation}_{start_year} {timelimstr} -o {log_dir}/{log_file}"
-        f" master_post.sh -p \'{' '.join(var_list)}\' -s {start_year} -e {end_year} -V"
+        f" master_post.sh -p \'{' '.join(var_list)}\' -s {start_year} -e {end_year} -V -O"
     )
     post_process = subprocess.run(
         post_command, shell=True, capture_output=True, text=True
@@ -184,7 +182,7 @@ def run_cmor(
         f" {deps_string} -o {log_dir}/{log_file}"
         f" master_cmor.sh -i ../../control_cmor/{control_cmor} -m {simulation}"
         f" -M 10 -v {','.join(var_list)} -s {start_year} -e {end_year}"
-        f" -n latest -V"
+        f" -n latest -V -O"
     )
     cmor_process = subprocess.run(
         cmor_command, shell=True, capture_output=True, text=True
@@ -214,7 +212,7 @@ def run_chunk(
         f" {deps_string} -o {log_dir}/{log_file}"
         f" master_cmor.sh -i ../../control_cmor/{control_cmor} -m {simulation}"
         f" -M 10 -v {','.join(var_list)} -s {start_year} -e {end_year}"
-        f" -n latest -V -c --remove"
+        f" -n latest -V -O -c --remove"
     )
     chunk_process = subprocess.run(
         chunk_command, shell=True, capture_output=True, text=True


### PR DESCRIPTION
A few updates/fixes:
- Updated the cmor table (+ a fix in the updating script)
- Updated the wrapper script to always overwrite old files. If a previous job fails, it may leave broken files, this is an attempt to make sure those don't affect the next try.
- A small fix to have all processed variable names in the cmorlight log filename, not only the first variable in the list given on command line.

@gnikulin : The updated table has updates to the "postitive" attribute fora few variables, but only tier1 ones as far as I can see. But that means those variables are missing this information in the current ERA5 tier1 cmorized variables.