### PR TITLE
prhmax special case

### DIFF
--- a/src/CMORlight/tools.py
+++ b/src/CMORlight/tools.py
@@ -1435,7 +1435,10 @@ is here the time resolution of the input data in hours."
                 cmd = "cdo -L -f %s -s -selhour,%s -seltimestep,%s %s %s %s" % (config.get_config_value('settings', 'cdo_nctype'),selhour,tsteps,cmd_mul,in_file,ftmp_name)
             else:
                 cmd = "cdo -L -f %s -s -timsel%s,%s -seltimestep,%s %s %s %s" % (config.get_config_value('settings', 'cdo_nctype'),cm,int(nstep),tsteps,cmd_mul,in_file,ftmp_name)
-        
+
+        # Special case, currently only for prhmax, which has cell method "time: mean within hours time: maximum over hours"
+        elif res == 'day' and 'maximum over hours' in cm_type:
+            cmd = "cdo -L -f %s -s daymax -seltimestep,%s %s %s %s" % (config.get_config_value('settings','cdo_nctype'),tsteps,cmd_mul,in_file,ftmp_name)
         # For monthly resolution daily processing is sometimes necessary first
         elif res == 'day' or 'within days time' in cm_type:
             cmd = "cdo -L -f %s -s day%s -seltimestep,%s %s %s %s" % (config.get_config_value('settings', 'cdo_nctype'),cm,tsteps,cmd_mul,in_file,ftmp_name)


### PR DESCRIPTION
Closes #37 

Basically copy-pasted the suggestion. I didn't get any errors during processing at least, you can check the result here:
`/nobackup/rossby27/proj/rossby/joint_exp/cordex/postprocess/HCLIM2CMOR/data_jl/OUT/202201/CORDEX/CMIP6/DD/EUR-12/HCLIMcom-SMHI/ERA5/evaluation/r1i1p1f1/HCLIM43-ALADIN/v1-r1/day/prhmax/latest`

`prhmax` is only available in daily output, and I only ran for ERA5. I'll move it to the new drive next week together with all the other data that is currently being copied.