### PR TITLE
Use requests instead of pooch

### DIFF
--- a/src/master_wrapper.py
+++ b/src/master_wrapper.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 import yaml
 
+import util.vartable_update
+
 
 CONSTANT_VARIABLES = ["orog", "sftlf", "sftnf", "sfturf", "sftlaf"]
 NO_CMOR_VARIABLES = ["clqvi", "mrrod"]  # Should not be cmorized
@@ -42,6 +44,14 @@ def parse_args():
         help=(
             "Cmorize constant (fixed) variables. If this flag is set, only"
             " constant variables in variables list will be cmorized."
+        )
+    )
+    parser.add_argument(
+        "-u",
+        "--update",
+        action=argparse.BooleanOptionalAction,
+        help=(
+            "Update variables table (fetches cmor tables from github)."
         )
     )
     return parser.parse_args()
@@ -224,6 +234,10 @@ def run_chunk(
 
 def main():
     args = parse_args()
+
+    if args.update:
+        util.vartable_update.update()
+
     config = read_simulation_config(args.file)
     log_dir = config["log_dir"]
     simulation_config = config["simulations"][args.simulation]


### PR DESCRIPTION
A small fix to the variables table update script:

- I'm changing from using `pooch` to `requests` for downloading the cmor tables from github. It is faster and don't require the files to be stored locally before using them. I had an idea when I first did this to use `pooch` for a local cache, but it didn't really pan out that well, and `requests` is a better choice now.

- I'm also adding an argument `-u`/`--update` to the `master_wrapper.py` script to allow for downloading/updating the variables table before post-processing/cmorization is started (requires the `requests` python package to be installed in the environment).